### PR TITLE
DEVEX-1881: Manage SAML Assertion api 

### DIFF
--- a/OneLoginClient/Endpoints.cs
+++ b/OneLoginClient/Endpoints.cs
@@ -42,5 +42,10 @@
         /// </summary>
         public const string ONELOGIN_REPORTS = "reports";
 
+        /// <summary>
+        /// https://api.<us_or_eu>.onelogin.com/api/2/saml-assertions
+        /// </summary>
+        public const string ONELOGIN_SAMLASSERTIONS = "saml-assertions";
+
     }
 }

--- a/OneLoginClient/OneLoginClientSAMLAssertionV2.cs
+++ b/OneLoginClient/OneLoginClientSAMLAssertionV2.cs
@@ -1,0 +1,48 @@
+﻿
+using OneLogin.Request;
+using OneLogin.Response;
+
+namespace OneLogin
+{
+    public partial class OneLoginClient
+    {
+        /// <summary>
+        /// Use this API to generate a SAML assertion.
+        /// If multi-factor authentication(MFA) is enabled, 
+        /// this API works in close conjunction with the Verify Factor API to provide and verify the second factor.
+        /// https://developers.onelogin.com/api-docs/2/saml-assertions/generate-saml-assertion
+        /// </summary>
+        /// <param name="request">The request object.</param>
+        /// <returns></returns>
+        public async Task<ApiResponse<GenerateSAMLAssertionResponse>> GenerateSAMLAssertion(GenerateSAMLAssertionRequest request)
+        {
+            try
+            {
+                return await PostResource<GenerateSAMLAssertionResponse>($"{Endpoints.ONELOGIN_SAMLASSERTIONS}", request, Endpoints.BaseApi2);
+            }
+            catch (Exception ex)
+            {
+                return new ApiResponse<GenerateSAMLAssertionResponse>(status: new BaseErrorResponse { Message = ex.Message, StatusCode = 500 });
+            }
+        }
+
+        /// <summary>
+        /// Verify a one-time password (OTP) value, provided for a second factor, when multi-factor authentication (MFA) is required for SAML authentication.
+        /// This API is used in close conjunction with the Generate SAML Assertion API when MFA is required
+        /// https://developers.onelogin.com/api-docs/2/saml-assertions/verify-factor
+        /// </summary>
+        /// <param name="request">The request object.</param>
+        /// <returns></returns>
+        public async Task<ApiResponse<VerifyFactorResponse>> VerifyFactor(VerifyFactorRequest request)
+        {
+            try
+            {
+                return await PostResource<VerifyFactorResponse>($"{Endpoints.ONELOGIN_SAMLASSERTIONS}/verify_factor", request, Endpoints.BaseApi2);
+            }
+            catch (Exception ex)
+            {
+                return new ApiResponse<VerifyFactorResponse>(status: new BaseErrorResponse { Message = ex.Message, StatusCode = 500 });
+            }
+        }
+    }
+}

--- a/OneLoginClient/Requests/GenerateSAMLAssertionRequest.cs
+++ b/OneLoginClient/Requests/GenerateSAMLAssertionRequest.cs
@@ -1,0 +1,37 @@
+﻿namespace OneLogin.Requests
+{
+    public class GenerateSAMLAssertionRequest
+    {
+        /// <summary>
+        /// The username or email of the OneLogin user accessing the app for which you want to generate a SAML token.
+        /// </summary>
+        [JsonPropertyName("username_or_email")]
+        public required string UsernameOrEmail { get; set; }
+
+        /// <summary>
+        /// The password of the OneLogin user accessing the app for which you want to generate a SAML token.
+        /// </summary>
+        [JsonPropertyName("password")]
+        public required string Password { get; set; }
+
+        /// <summary>
+        /// The App ID of the app for which you want to generate a SAML token. This is the app ID in OneLogin.
+        /// </summary>
+        [JsonPropertyName("app_id")]
+        public required long AppId { get; set; }
+
+        /// <summary>
+        /// The subdomain of the OneLogin user accessing the app for which you want to generate a SAML token.
+        /// For example, if your OneLogin URL is splinkly.onelogin.com, enter splinkly as the subdomain value.
+        /// </summary>
+        [JsonPropertyName("subdomain")]
+        public required string Subdomain { get; set; }
+
+        /// <summary>
+        /// The IP address of the user accessing the application. Used to determine if MFA is required or should be bypassed.
+        /// This is optional and should be passed in if IP allow-listing is required by the MFA policies.
+        /// </summary>
+        [JsonPropertyName("ip_address")]
+        public string? IpAddress { get; set; }
+    }
+}

--- a/OneLoginClient/Requests/VerifyFactorRequest.cs
+++ b/OneLoginClient/Requests/VerifyFactorRequest.cs
@@ -1,0 +1,44 @@
+﻿namespace OneLogin.Request
+{
+    public class VerifyFactorRequest
+    {
+        /// <summary>
+        /// The App ID of the app for which you want to generate a SAML token. 
+        /// This is the app ID in OneLogin.
+        /// </summary>
+        [JsonPropertyName("app_id")]
+        public string AppId { get; set; }
+
+        /// <summary>
+        /// The MFA device_id you are submitting for verification. 
+        /// The device_id is supplied by the Generate SAML Assertion API.
+        /// </summary>
+        [JsonPropertyName("device_id")]
+        public string DeviceId { get; set; }
+
+        /// <summary>
+        /// The state_token associated with the MFA device_id you are submitting for verification. 
+        /// The state_token is supplied by the Generate SAML Assertion API.
+        /// </summary>
+        [JsonPropertyName("state_token")]
+        public string StateToken { get; set; }
+
+        /// <summary>
+        /// The OTP (One-Time Password) value for the MFA factor you are submitting for verification.
+        /// For some MFA factors (e.g., OneLogin OTP SMS), the OTP is provided by the user separately.
+        /// If not included, a 200 OK - Pending result is returned, and a subsequent call is needed with the OTP value.
+        /// In the case of other MFA factors (e.g., Google Authenticator, Yubikey), the OTP value is required immediately.
+        /// </summary>
+        [JsonPropertyName("otp_token")]
+        public string? OtpToken { get; set; }
+
+        /// <summary>
+        /// When verifying MFA via Protect Push, set this to true to stop additional push notifications 
+        /// being sent to the OneLogin Protect device.
+        /// Set to false in the first request to trigger a notification requesting MFA. 
+        /// In subsequent requests, set this to true while polling for the user’s approve/deny response.
+        /// </summary>
+        [JsonPropertyName("do_not_notify")]
+        public bool DoNotNotify { get; set; }
+    }
+}

--- a/OneLoginClient/Responses/GenerateSAMLAssertionResponse.cs
+++ b/OneLoginClient/Responses/GenerateSAMLAssertionResponse.cs
@@ -1,0 +1,94 @@
+﻿
+namespace OneLogin.Responses
+{
+    /// <summary>
+    /// https://developers.onelogin.com/api-docs/2/saml-assertions/generate-saml-assertion
+    /// </summary>
+    public class GenerateSAMLAssertionResponse
+    {
+        /// <summary>
+        /// Provides the SAML assertion. Returned only when MFA is not required.
+        /// </summary>
+        [JsonPropertyName("data")]
+        public string? Data { get; set; }
+
+        /// <summary>
+        /// Plain text description describing the outcome of the response.
+        /// </summary>
+        [JsonPropertyName("message")]
+        public string? Message { get; set; }
+
+        /// <summary>
+        /// Provides the state_token value that must be submitted with each Verify Factor API call until the SAML assertion has been issued.
+        /// Returned only when MFA is required.
+        /// </summary>
+        [JsonPropertyName("state_token")]
+        public string? StateToken { get; set; }
+
+        /// <summary>
+        /// Provides information about the user that will be logged in via the SAML assertion.
+        /// </summary>
+        [JsonPropertyName("user")]
+        public User? User { get; set; }
+
+        /// <summary>
+        /// Provides device values that must be submitted with the Verify Factor API call.
+        /// </summary>
+        [JsonPropertyName("devices")]
+        public List<Device>? Devices { get; set; }
+
+        /// <summary>
+        /// Provides the Verify Factor API endpoint to which the device_id, state_token, app_id, and otp_token must be sent for verification.
+        /// Returned only when MFA is required.
+        /// </summary>
+        [JsonPropertyName("callback_url")]
+        public string? CallbackUrl { get; set; }
+    }
+    public class User
+    {
+        /// <summary>
+        /// The last name of the user to be logged in via the SAML assertion.
+        /// </summary>
+        [JsonPropertyName("lastname")]
+        public string? Lastname { get; set; }
+
+        /// <summary>
+        /// The username of the user to be logged in via the SAML assertion.
+        /// </summary>
+        [JsonPropertyName("username")]
+        public string? Username { get; set; }
+
+        /// <summary>
+        /// The email of the user to be logged in via the SAML assertion.
+        /// </summary>
+        [JsonPropertyName("email")]
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// The first name of the user to be logged in via the SAML assertion.
+        /// </summary>
+        [JsonPropertyName("firstname")]
+        public string? Firstname { get; set; }
+
+        /// <summary>
+        /// The unique ID of the user to be logged in via the SAML assertion.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public long Id { get; set; }
+    }
+
+    public class Device
+    {
+        /// <summary>
+        /// Lists an available MFA device type, such as OneLogin OTP SMS or Google Authenticator.
+        /// </summary>
+        [JsonPropertyName("device_type")]
+        public string? DeviceType { get; set; }
+
+        /// <summary>
+        /// Lists an ID for the device type that must be submitted with the Verify Factor API call.
+        /// </summary>
+        [JsonPropertyName("device_id")]
+        public long? DeviceId { get; set; }
+    }
+}

--- a/OneLoginClient/Responses/VerifyFactorResponse.cs
+++ b/OneLoginClient/Responses/VerifyFactorResponse.cs
@@ -1,0 +1,19 @@
+﻿namespace OneLogin.Response
+{
+    public class VerifyFactorResponse
+    {
+        /// <summary>
+        /// Provides the SAML assertion.
+        /// This field is returned only when MFA is not required.
+        /// </summary>
+        [JsonPropertyName("data")]
+        public string Data { get; set; }
+
+        /// <summary>
+        /// A plain text description describing the outcome of the response.
+        /// This is typically a status or error message explaining the result of the request.
+        /// </summary>
+        [JsonPropertyName("message")]
+        public string Message { get; set; }
+    }
+}


### PR DESCRIPTION
This pull request introduces several new API endpoints and response types to the OneLoginClient project. The primary focus is on enhancing the functionality for managing SAML Assertion within the OneLogin API. Below are the most important changes:

**New Endpoints and Methods**:
[OneLoginClient/OneLoginClientSAMLAssertionV2.cs](https://github.com/onelogin/onelogin-dotnet-sdk/blob/Manage-SAML-Assertions/OneLoginClient/OneLoginClientSAMLAssertionV2.cs): Added methods for Generate SAMLAssertion and Verify Factor.

**Constants**:
[OneLoginClient/Endpoints.cs](https://github.com/onelogin/onelogin-dotnet-sdk/blob/Manage-SAML-Assertions/OneLoginClient/Endpoints.cs): Added constants ONELOGIN_SAMLASSERTIONS for the new endpoints.

Response Types:
[OneLoginClient/Responses/GenerateSAMLAssertionResponse.cs](https://github.com/onelogin/onelogin-dotnet-sdk/blob/Manage-SAML-Assertions/OneLoginClient/Responses/GenerateSAMLAssertionResponse.cs): Introduced the GenerateSAMLAssertionResponse class to represent SAML Assertion data.

Request Types:
[OneLoginClient/Request/GenerateSAMLAssertionRequest.cs](https://github.com/onelogin/onelogin-dotnet-sdk/blob/Manage-SAML-Assertions/OneLoginClient/Requests/GenerateSAMLAssertionRequest.cs): Introduced the GenerateSAMLAssertionRequest class to represent SAML Assertion payload data.
